### PR TITLE
analiticcl-evaluation-tool: allow enabling/disabling version menu independently of developmentMode

### DIFF
--- a/analiticcl-evaluation-tool/front/Makefile
+++ b/analiticcl-evaluation-tool/front/Makefile
@@ -1,7 +1,7 @@
 all: help
 tag = ga-analiticcl-evaluate-front
 
-.PHONY: build docker-image start help push update-version
+.PHONY: build docker-image start help push update-version with-versions without-versions
 
 .make:
 	mkdir -p .make
@@ -46,6 +46,14 @@ dev-config:
 prod-config:
 	@echo "set developmentMode to false"
 	@jq ".developmentMode=false" src/config.json > /tmp/config.json && mv /tmp/config.json src/
+
+with-versions:
+	@echo "enabled version menu"
+	@jq ".versionSelector=true" src/config.json > /tmp/config.json && mv /tmp/config.json src/
+
+without-versions:
+	@echo "disabled version menu"
+	@jq ".versionSelector=false" src/config.json > /tmp/config.json && mv /tmp/config.json src/
 
 
 help:

--- a/analiticcl-evaluation-tool/front/README.md
+++ b/analiticcl-evaluation-tool/front/README.md
@@ -1,5 +1,7 @@
 # Analiticcl Evaluation Tool
-Tool to evaluate the annotations made by Analiticcl on a set of texts extracted from pagexml. 
+Tool to evaluate the annotations made by Analiticcl on a set of texts extracted from pagexml.
+
+Note: Adds `versionSelector=true` to `src/config.json` to activate the version pull-down.
 
 ## scripts
 
@@ -13,4 +15,5 @@ Builds the app for production to the `build` folder.
 
 ### ```make dev-config```
 
-Adds `developmentMode=true` to the src/config.json; this will activate the version pull-down.
+Adds `developmentMode=true` to the src/config.json
+

--- a/analiticcl-evaluation-tool/front/src/App.tsx
+++ b/analiticcl-evaluation-tool/front/src/App.tsx
@@ -61,6 +61,7 @@ interface InitData {
 const config: {} = require("./config.json");
 const version = config["version"];
 const inDevelopmentMode = config["developmentMode"];
+const versionSelector = config["versionSelector"]; //show version menu?
 const apiBase = inDevelopmentMode ? "http://localhost:8000" : "/api"; // production; proxied to back-end in nginx.conf
 
 const annotations0: Annotation[] = [];
@@ -380,7 +381,7 @@ const App = () => {
               checks={checks}
               onChange={handleTextChange}
             />
-            {inDevelopmentMode ? (
+            {versionSelector ? (
               <>
                 &nbsp;|&nbsp;
                 <VersionSelector

--- a/analiticcl-evaluation-tool/front/src/config.json
+++ b/analiticcl-evaluation-tool/front/src/config.json
@@ -1,4 +1,5 @@
 {
   "version": "2022.03.23",
-  "developmentMode": true
+  "developmentMode": false,
+  "versionSelector": true
 }


### PR DESCRIPTION
developmentMode has a hard-coded URL that conflicts with my development setup,  but I do need the version selector.